### PR TITLE
Starting item tweaks

### DIFF
--- a/Mystery.py
+++ b/Mystery.py
@@ -213,7 +213,7 @@ def roll_settings(weights):
     startitems = []
     for item in inventoryweights.keys():
         itemvalue = get_choice(item, inventoryweights)
-        if 'Progressive' in item and isinstance(itemvalue, int):
+        if item.startswith(('Progressive ', 'Small Key ', 'Rupee', 'Piece of Heart', 'Boss Heart Container', 'Sanctuary Heart Container', 'Arrow', 'Bombs ', 'Bomb ', 'Bottle')) and isinstance(itemvalue, int):
             for i in range(int(get_choice(item, inventoryweights))):
                 startitems.append(item)
         if get_choice(item, inventoryweights):

--- a/Mystery.py
+++ b/Mystery.py
@@ -212,8 +212,14 @@ def roll_settings(weights):
     inventoryweights = weights.get('startinventory', {})
     startitems = []
     for item in inventoryweights.keys():
+        itemvalue = get_choice(item, inventoryweights)
+        if 'Progressive' in item and isinstance(itemvalue, int):
+            for i in range(int(get_choice(item, inventoryweights))):
+                startitems.append(item)
         if get_choice(item, inventoryweights):
             startitems.append(item)
+    if glitches_required in ['no_logic'] and 'Pegasus Boots' not in startitems:
+        startitems.append('Pegasus Boots')
     ret.startinventory = ','.join(startitems)
 
     if 'rom' in weights:


### PR DESCRIPTION
* Add in capability to start with Progressive items higher than the first level.
* Auto-start no-logic seeds with Pegasus Boots.

``` #example
startinventory:
  Progressive Sword:
    0: 81 #Swordless
    1: 108 #Fisher Price sword
    2: 54 #Master sword
    3: 12 #Tempered sword
    4: 1 #Butter sword
```